### PR TITLE
Profile settings skeleton

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -18,6 +18,7 @@
    "react/react-in-jsx-scope": "off",
    "react/prop-types": "off",
    "react-hooks/rules-of-hooks": "error",
-   "react-hooks/exhaustive-deps": "error"
+   "react-hooks/exhaustive-deps": "error",
+   "prettier/prettier": 0
   }
 }

--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -19,6 +19,5 @@
    "react/prop-types": "off",
    "react-hooks/rules-of-hooks": "error",
    "react-hooks/exhaustive-deps": "error",
-   "prettier/prettier": 0
   }
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,7 +16,7 @@ function App(): JSX.Element {
     <MuiThemeProvider theme={theme}>
       <BrowserRouter>
         <SnackBarProvider>
-          {/* <AuthProvider> */}
+          <AuthProvider>
           <SocketProvider>
             <Switch>
               <Route exact path="/login" component={Login} />
@@ -30,7 +30,7 @@ function App(): JSX.Element {
               </Route>
             </Switch>
           </SocketProvider>
-          {/* </AuthProvider> */}
+          </AuthProvider>
         </SnackBarProvider>
       </BrowserRouter>
     </MuiThemeProvider>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Route, Redirect, Switch } from 'react-router-dom';
 import Login from './pages/Login/Login';
 import Signup from './pages/SignUp/SignUp';
 import Dashboard from './pages/Dashboard/Dashboard';
+import Profile from './pages/Profile/Profile';
 import { AuthProvider } from './context/useAuthContext';
 import { SocketProvider } from './context/useSocketContext';
 import { SnackBarProvider } from './context/useSnackbarContext';
@@ -16,18 +17,19 @@ function App(): JSX.Element {
       <BrowserRouter>
         <SnackBarProvider>
           <AuthProvider>
-            <SocketProvider>
-              <Switch>
-                <Route exact path="/login" component={Login} />
-                <Route exact path="/signup" component={Signup} />
-                <Route exact path="/dashboard">
-                  <Dashboard />
-                </Route>
-                <Route path="*">
-                  <Redirect to="/login" />
-                </Route>
-              </Switch>
-            </SocketProvider>
+          <SocketProvider>
+            <Switch>
+              <Route exact path="/login" component={Login} />
+              <Route exact path="/signup" component={Signup} />
+              <Route exact path="/profile" component={Profile} />
+              <Route exact path="/dashboard">
+                <Dashboard />
+              </Route>
+              <Route path="*">
+                <Redirect to="/login" />
+              </Route>
+            </Switch>
+          </SocketProvider>
           </AuthProvider>
         </SnackBarProvider>
       </BrowserRouter>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,12 +16,12 @@ function App(): JSX.Element {
     <MuiThemeProvider theme={theme}>
       <BrowserRouter>
         <SnackBarProvider>
-          <AuthProvider>
+          {/* <AuthProvider> */}
           <SocketProvider>
             <Switch>
               <Route exact path="/login" component={Login} />
               <Route exact path="/signup" component={Signup} />
-              <Route exact path="/profile" component={Profile} />
+              <Route exact path="/profile/:menuitem" component={Profile} />
               <Route exact path="/dashboard">
                 <Dashboard />
               </Route>
@@ -30,7 +30,7 @@ function App(): JSX.Element {
               </Route>
             </Switch>
           </SocketProvider>
-          </AuthProvider>
+          {/* </AuthProvider> */}
         </SnackBarProvider>
       </BrowserRouter>
     </MuiThemeProvider>

--- a/client/src/components/EditProfile/EditProfile.tsx
+++ b/client/src/components/EditProfile/EditProfile.tsx
@@ -1,0 +1,8 @@
+import { Grid } from '@material-ui/core';
+import useStyles from './useStyles';
+
+export default function EditProfile(): JSX.Element {
+  const classes = useStyles();
+
+  return <Grid>This is the Edit Profile section.</Grid>
+}

--- a/client/src/components/EditProfile/useStyles.ts
+++ b/client/src/components/EditProfile/useStyles.ts
@@ -1,0 +1,5 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({}));
+
+export default useStyles;

--- a/client/src/components/Payment/Payment.tsx
+++ b/client/src/components/Payment/Payment.tsx
@@ -1,0 +1,9 @@
+import { Grid } from '@material-ui/core';
+import useStyles from './useStyles';
+
+export default function Payment(): JSX.Element {
+  const classes = useStyles();
+
+  return <Grid>This is the Payment section.</Grid>
+
+}

--- a/client/src/components/Payment/useStyles.ts
+++ b/client/src/components/Payment/useStyles.ts
@@ -1,0 +1,5 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({}));
+
+export default useStyles;

--- a/client/src/components/ProfilePhoto/ProfilePhoto.tsx
+++ b/client/src/components/ProfilePhoto/ProfilePhoto.tsx
@@ -1,0 +1,9 @@
+import { Grid } from '@material-ui/core';
+import useStyles from './useStyles';
+
+export default function ProfilePhoto(): JSX.Element {
+  const classes = useStyles();
+
+  return <Grid>This is the Profile Photo section.</Grid>
+
+}

--- a/client/src/components/ProfilePhoto/useStyles.ts
+++ b/client/src/components/ProfilePhoto/useStyles.ts
@@ -1,0 +1,5 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({}));
+
+export default useStyles;

--- a/client/src/components/Security/Security.tsx
+++ b/client/src/components/Security/Security.tsx
@@ -1,0 +1,9 @@
+import { Grid } from '@material-ui/core';
+import useStyles from './useStyles';
+
+export default function Security(): JSX.Element {
+  const classes = useStyles();
+
+  return <Grid>This is the Security section.</Grid>
+
+}

--- a/client/src/components/Security/useStyles.ts
+++ b/client/src/components/Security/useStyles.ts
@@ -1,0 +1,5 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({}));
+
+export default useStyles;

--- a/client/src/components/Settings/Settings.tsx
+++ b/client/src/components/Settings/Settings.tsx
@@ -1,0 +1,9 @@
+import { Grid } from '@material-ui/core';
+import useStyles from './useStyles';
+
+export default function Settings(): JSX.Element {
+  const classes = useStyles();
+
+  return <Grid>This is the Settings section.</Grid>
+
+}

--- a/client/src/components/Settings/useStyles.ts
+++ b/client/src/components/Settings/useStyles.ts
@@ -1,0 +1,5 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({}));
+
+export default useStyles;

--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react"
+import { Grid, Container, Typography, Link } from '@material-ui/core';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import useStyles from './useStyles';
+import ChatSideBanner from '../../components/ChatSideBanner/ChatSideBanner';
+import EditProfile from '../../components/EditProfile/EditProfile'
+import ProfilePhoto from '../../components/ProfilePhoto/ProfilePhoto'
+import Payment from '../../components/Payment/Payment'
+import Security from '../../components/Security/Security'
+import Settings from '../../components/Settings/Settings'
+
+
+export default function Profile(): JSX.Element {
+  const classes = useStyles();
+
+  const [currentSection, setCurrentSection] = useState("EditProfile")
+
+  const handleClick = (section: string) => {
+    setCurrentSection(section)
+  }
+
+  return (
+    <Grid container className={`${classes.root}`}>
+      <CssBaseline />
+      {/* <ChatSideBanner /> */}
+      <Grid className={`${classes.menuItems}`}>
+        <Link 
+          onClick={() => handleClick("EditProfile")} 
+          className={`${classes.menuItem} ${currentSection === "EditProfile" && classes.selectedMenuItem}`} 
+          underline="none"
+        > 
+          Edit Profile 
+        </Link>
+        <Link 
+          onClick={() => handleClick("ProfilePhoto")} 
+          className={`${classes.menuItem} ${currentSection === "ProfilePhoto" && classes.selectedMenuItem}`} 
+          underline="none"
+        > 
+          Profile Photo 
+        </Link>
+        <Link 
+          onClick={() => handleClick("Availability")} 
+          className={`${classes.menuItem} ${currentSection === "Availability" && classes.selectedMenuItem}`} 
+          underline="none"
+        > 
+          Availability 
+        </Link>
+        <Link 
+          onClick={() => handleClick("Payment")} 
+          className={`${classes.menuItem} ${currentSection === "Payment" && classes.selectedMenuItem}`} 
+          underline="none"
+        > 
+          Payment 
+        </Link>
+        <Link 
+          onClick={() => handleClick("Security")} 
+          className={`${classes.menuItem} ${currentSection === "Security" && classes.selectedMenuItem}`} 
+          underline="none"
+        > 
+          Security 
+        </Link>
+        <Link 
+          onClick={() => handleClick("Settings")} 
+          className={`${classes.menuItem} ${currentSection === "Settings" && classes.selectedMenuItem}`} 
+          underline="none"
+        > 
+          Settings 
+        </Link>
+      </Grid>
+      <Container maxWidth="sm" >
+        {currentSection === "EditProfile" && <EditProfile />}
+        {currentSection === "ProfilePhoto" && <ProfilePhoto />}
+        {currentSection === "Payment" && <Payment />}
+        {currentSection === "Security" && <Security />}
+        {currentSection === "Settings" && <Settings />}
+      </Container>
+    </Grid>
+  );
+}

--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -2,7 +2,6 @@ import { useState } from "react"
 import { Grid, Container, Typography, Link } from '@material-ui/core';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import useStyles from './useStyles';
-import ChatSideBanner from '../../components/ChatSideBanner/ChatSideBanner';
 import EditProfile from '../../components/EditProfile/EditProfile'
 import ProfilePhoto from '../../components/ProfilePhoto/ProfilePhoto'
 import Payment from '../../components/Payment/Payment'
@@ -10,69 +9,47 @@ import Security from '../../components/Security/Security'
 import Settings from '../../components/Settings/Settings'
 
 
-export default function Profile(): JSX.Element {
+export default function Profile(props: any): JSX.Element {
+
+  const MENU_LIST = [
+    "Edit Profile",
+    "Profile Photo",
+    "Availability",
+    "Payment",
+    "Security",
+    "Settings"
+  ]
+
   const classes = useStyles();
 
-  const [currentSection, setCurrentSection] = useState("EditProfile")
+  const [currentSection, setCurrentSection] = useState(props.match.params.menuitem)
 
   const handleClick = (section: string) => {
     setCurrentSection(section)
+    props.history.push(`/profile/${section}`)
   }
 
   return (
     <Grid container className={`${classes.root}`}>
       <CssBaseline />
-      {/* <ChatSideBanner /> */}
       <Grid className={`${classes.menuItems}`}>
-        <Link 
-          onClick={() => handleClick("EditProfile")} 
-          className={`${classes.menuItem} ${currentSection === "EditProfile" && classes.selectedMenuItem}`} 
-          underline="none"
-        > 
-          Edit Profile 
-        </Link>
-        <Link 
-          onClick={() => handleClick("ProfilePhoto")} 
-          className={`${classes.menuItem} ${currentSection === "ProfilePhoto" && classes.selectedMenuItem}`} 
-          underline="none"
-        > 
-          Profile Photo 
-        </Link>
-        <Link 
-          onClick={() => handleClick("Availability")} 
-          className={`${classes.menuItem} ${currentSection === "Availability" && classes.selectedMenuItem}`} 
-          underline="none"
-        > 
-          Availability 
-        </Link>
-        <Link 
-          onClick={() => handleClick("Payment")} 
-          className={`${classes.menuItem} ${currentSection === "Payment" && classes.selectedMenuItem}`} 
-          underline="none"
-        > 
-          Payment 
-        </Link>
-        <Link 
-          onClick={() => handleClick("Security")} 
-          className={`${classes.menuItem} ${currentSection === "Security" && classes.selectedMenuItem}`} 
-          underline="none"
-        > 
-          Security 
-        </Link>
-        <Link 
-          onClick={() => handleClick("Settings")} 
-          className={`${classes.menuItem} ${currentSection === "Settings" && classes.selectedMenuItem}`} 
-          underline="none"
-        > 
-          Settings 
-        </Link>
+        {MENU_LIST.map(item => (
+          <Link
+            onClick={() => handleClick(item.replace(/\s/g, "").toLowerCase())}
+            className={`${classes.menuItem} ${currentSection === item.replace(/\s/g, "") && classes.selectedMenuItem}`} 
+            underline="none"
+            key={item}
+          >
+            {item}
+          </Link>
+        ))}
       </Grid>
-      <Container maxWidth="sm" >
-        {currentSection === "EditProfile" && <EditProfile />}
-        {currentSection === "ProfilePhoto" && <ProfilePhoto />}
-        {currentSection === "Payment" && <Payment />}
-        {currentSection === "Security" && <Security />}
-        {currentSection === "Settings" && <Settings />}
+      <Container maxWidth="sm" className={classes.menuContainer}>
+        {currentSection === "editprofile" && <EditProfile />}
+        {currentSection === "profilephoto" && <ProfilePhoto />}
+        {currentSection === "payment" && <Payment />}
+        {currentSection === "security" && <Security />}
+        {currentSection === "settings" && <Settings />}
       </Container>
     </Grid>
   );

--- a/client/src/pages/Profile/useStyles.ts
+++ b/client/src/pages/Profile/useStyles.ts
@@ -1,0 +1,30 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  root: { 
+    backgroundColor: "#FAFAFB",
+    position: "absolute",
+    top: 0,
+    left: 0,
+    width: "100%",
+    height: "100%",
+    marginTop: "50px",
+  },
+  menuItem: {
+    fontSize: "1.1rem",
+    margin: "10px 40px",
+    color: '#8D8D8D',
+    hover: "none",
+    fontWeight: 800,
+  },
+  selectedMenuItem: {
+    color: '#000000'
+  },
+  menuItems: {
+    display: "flex",
+    flexDirection: "column",
+    cursor: "pointer"
+  },
+}));
+
+export default useStyles;

--- a/client/src/pages/Profile/useStyles.ts
+++ b/client/src/pages/Profile/useStyles.ts
@@ -25,6 +25,11 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: "column",
     cursor: "pointer"
   },
+  menuContainer: {
+    boxShadow: "0px 0px 8px #CACACA",
+    borderRadius: "5px",
+    height: "80vh"
+  }
 }));
 
 export default useStyles;

--- a/client/src/themes/theme.ts
+++ b/client/src/themes/theme.ts
@@ -15,4 +15,5 @@ export const theme = createMuiTheme({
   shape: {
     borderRadius: 5,
   },
+
 });

--- a/server/db.js
+++ b/server/db.js
@@ -1,5 +1,6 @@
 const mongoose = require("mongoose");
 
+
 const connectDB = async () => {
   const conn = await mongoose.connect(process.env.MONGO_URI, {
     useNewUrlParser: true,

--- a/server/sample.env
+++ b/server/sample.env
@@ -1,0 +1,3 @@
+JWT_SECRET=
+MONGO_URI=
+TEAM_NAMES=Bonnie,Sina,David

--- a/server/sample.env
+++ b/server/sample.env
@@ -1,3 +1,3 @@
-JWT_SECRET=
-MONGO_URI=
-TEAM_NAMES=Bonnie,Sina
+JWT_SECRET= 
+MONGO_URI= 
+TEAM_NAMES=Bonnie,Sina, Wilson

--- a/server/sample.env
+++ b/server/sample.env
@@ -1,3 +1,0 @@
-JWT_SECRET= 
-MONGO_URI= 
-TEAM_NAMES=Bonnie,Sina, Wilson


### PR DESCRIPTION
### What this PR does (required):
- Sidebar of the profile settings is complete
- Use can click on each menu item and it will go to that section of the profile settings menu

### Screenshots / Videos (required):
https://www.loom.com/share/3a9e8ddf27f248cdbf21bb8951e26c49

### Any information needed to test this feature (required):
- Run `npm run start`

### Any issues with the current functionality (optional):
- components were created for each section of the profile settings (edit profile, profile photo, availability, payment, security, settings)
- to access the "Profile" page, the "AuthProvider" context in the app.tsx file must be disabled because auth is not working yet
