### PR TITLE
returning profile on log in and saving it in the authContext

### DIFF
--- a/client/src/components/NavBar/NavBar.tsx
+++ b/client/src/components/NavBar/NavBar.tsx
@@ -27,9 +27,9 @@ import SignupHeader from '../SignUpHeader/SignUpHeader';
 
 const NavBar = (): JSX.Element => {
   const classes = useStyles();
-  const { loggedInUser, logout } = useAuth();
+  const { loggedInUser, logout, userProfile } = useAuth();
   const [anchorEl, setAnchorEl] = React.useState<Element | null>(null);
-
+  console.log(userProfile);
   const handleMenuClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(e.currentTarget);
   };
@@ -54,19 +54,17 @@ const NavBar = (): JSX.Element => {
           </Link>
           <Grid container alignItems="center" direction="row" className={classes.toolbarLeftContainer}>
             {!loggedInUser && (
-          <AppBar position="relative" elevation={0} className={classes.appBar}>
-            <Toolbar className={classes.toolbar}>
+              <AppBar position="relative" elevation={0} className={classes.appBar}>
+                <Toolbar className={classes.toolbar}>
                   <Grid container direction="row" justify="flex-end" alignItems="center">
-                    <Hidden only={["sm", "md", "lg", "xl"]}>
-                      <MenuIcon color="primary" className={classes.menuIcon}/>
+                    <Hidden only={['sm', 'md', 'lg', 'xl']}>
+                      <MenuIcon color="primary" className={classes.menuIcon} />
                     </Hidden>
                     <Hidden only={['xs']}>
-                      <Hidden only={['xs', "sm"]}>
+                      <Hidden only={['xs', 'sm']}>
                         <Typography className={classes.toolbarLink}>
-                          <Link 
-                          className={classes.secondaryLink} 
-                          href='/sitters'>
-                            Become a Sitter 
+                          <Link className={classes.secondaryLink} href="/sitters">
+                            Become a Sitter
                           </Link>
                         </Typography>
                       </Hidden>
@@ -74,9 +72,8 @@ const NavBar = (): JSX.Element => {
                       <SignupHeader linkTo="/signup" btnText="Sign Up" />
                     </Hidden>
                   </Grid>
-                
-            </Toolbar>
-          </AppBar> 
+                </Toolbar>
+              </AppBar>
             )}
             {loggedInUser && (
               <Grid item xs={10} sm={6} md={4} className={classes.toolbarLeft}>

--- a/client/src/components/NavBar/NavBar.tsx
+++ b/client/src/components/NavBar/NavBar.tsx
@@ -29,7 +29,7 @@ const NavBar = (): JSX.Element => {
   const classes = useStyles();
   const { loggedInUser, logout, userProfile } = useAuth();
   const [anchorEl, setAnchorEl] = React.useState<Element | null>(null);
-  console.log(userProfile);
+
   const handleMenuClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(e.currentTarget);
   };

--- a/client/src/context/useAuthContext.tsx
+++ b/client/src/context/useAuthContext.tsx
@@ -2,17 +2,20 @@ import { useState, useContext, createContext, FunctionComponent, useEffect, useC
 import { useHistory } from 'react-router-dom';
 import { AuthApiData, AuthApiDataSuccess } from '../interface/AuthApiData';
 import { User } from '../interface/User';
+import { Profile } from '../interface/Profile';
 import loginWithCookies from '../helpers/APICalls/loginWithCookies';
 import logoutAPI from '../helpers/APICalls/logout';
 
 interface IAuthContext {
   loggedInUser: User | null | undefined;
+  userProfile: Profile | null | undefined;
   updateLoginContext: (data: AuthApiDataSuccess) => void;
   logout: () => void;
 }
 
 export const AuthContext = createContext<IAuthContext>({
   loggedInUser: undefined,
+  userProfile: undefined,
   updateLoginContext: () => null,
   logout: () => null,
 });
@@ -20,9 +23,11 @@ export const AuthContext = createContext<IAuthContext>({
 export const AuthProvider: FunctionComponent = ({ children }): JSX.Element => {
   // default undefined before loading, once loaded provide user or null if logged out
   const [loggedInUser, setLoggedInUser] = useState<User | null | undefined>();
+  const [userProfile, setUserProfile] = useState<Profile | null | undefined>();
   const history = useHistory();
   const updateLoginContext = useCallback((data: AuthApiDataSuccess) => {
     setLoggedInUser(data.user);
+    setUserProfile(data.profile);
   }, []);
 
   const logout = useCallback(async () => {
@@ -31,6 +36,7 @@ export const AuthProvider: FunctionComponent = ({ children }): JSX.Element => {
       .then(() => {
         history.push('/login');
         setLoggedInUser(null);
+        setUserProfile(null);
       })
       .catch((error) => console.error(error));
   }, [history]);
@@ -44,6 +50,8 @@ export const AuthProvider: FunctionComponent = ({ children }): JSX.Element => {
         } else {
           // don't need to provide error feedback as this just means user doesn't have saved cookies or the cookies have not been authenticated on the backend
           setLoggedInUser(null);
+          setUserProfile(null);
+
           // history.push('/landing');
         }
       });
@@ -51,7 +59,11 @@ export const AuthProvider: FunctionComponent = ({ children }): JSX.Element => {
     checkLoginWithCookies();
   }, [updateLoginContext, history]);
 
-  return <AuthContext.Provider value={{ loggedInUser, updateLoginContext, logout }}>{children}</AuthContext.Provider>;
+  return (
+    <AuthContext.Provider value={{ loggedInUser, userProfile, updateLoginContext, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
 };
 
 export function useAuth(): IAuthContext {

--- a/client/src/interface/AuthApiData.ts
+++ b/client/src/interface/AuthApiData.ts
@@ -1,11 +1,11 @@
-import { AnyARecord } from 'dns';
 import { User } from './User';
+import { Profile } from './Profile';
 
 export interface AuthApiDataSuccess {
   message: string;
   user: User;
   token: string;
-  profile: any;
+  profile: Profile;
 }
 
 export interface AuthApiData {

--- a/client/src/interface/AuthApiData.ts
+++ b/client/src/interface/AuthApiData.ts
@@ -1,9 +1,11 @@
+import { AnyARecord } from 'dns';
 import { User } from './User';
 
 export interface AuthApiDataSuccess {
   message: string;
   user: User;
   token: string;
+  profile: any;
 }
 
 export interface AuthApiData {

--- a/client/src/interface/Profile.ts
+++ b/client/src/interface/Profile.ts
@@ -1,0 +1,25 @@
+export interface Profile {
+  userId: string;
+  firstName: string;
+  lastName: string;
+  description: string;
+  location: string;
+  images: string[];
+  isDogSitter: boolean;
+  availabilityWeek: {
+    monday: boolean;
+    tuesday: boolean;
+    wednesday: boolean;
+    thursday: boolean;
+    friday: boolean;
+    saturday: boolean;
+    sunday: boolean;
+  };
+  availabilityDays: {
+    additionalDays: Date;
+    offDays: Date;
+  };
+  rating: number;
+  hourlyRate: number;
+  tagLine: string;
+}

--- a/client/src/mocks/mockProfile.ts
+++ b/client/src/mocks/mockProfile.ts
@@ -1,0 +1,108 @@
+import { string } from 'yup/lib/locale';
+import { Profile } from '../interface/Profile';
+
+const mockUserProfile: Profile = {
+  userId: 'mockUserId',
+  firstName: 'mockFirstName',
+  lastName: 'mockLaastName',
+  description: 'mockdesc',
+  location: 'mock location',
+  images: ['test1', 'test2', 'test3'],
+  isDogSitter: false,
+  availabilityWeek: {
+    monday: false,
+    tuesday: true,
+    wednesday: false,
+    thursday: false,
+    friday: true,
+    saturday: true,
+    sunday: true,
+  },
+  availabilityDays: {
+    additionalDays: new Date(),
+    offDays: new Date(),
+  },
+  rating: 2,
+  hourlyRate: 25,
+  tagLine: 'mock tag',
+};
+
+const mockOtherUserProfile1: Profile = {
+  userId: 'mockUserId',
+  firstName: 'mockFirstName',
+  lastName: 'mockLaastName',
+  description: 'mockdesc',
+  location: 'mock location',
+  images: ['test1', 'test2', 'test3'],
+  isDogSitter: false,
+  availabilityWeek: {
+    monday: false,
+    tuesday: true,
+    wednesday: false,
+    thursday: false,
+    friday: true,
+    saturday: true,
+    sunday: true,
+  },
+  availabilityDays: {
+    additionalDays: new Date(),
+    offDays: new Date(),
+  },
+  rating: 2,
+  hourlyRate: 25,
+  tagLine: 'mock tag',
+};
+const mockOtherUserProfile2: Profile = {
+  userId: 'mockUserId',
+  firstName: 'mockFirstName',
+  lastName: 'mockLaastName',
+  description: 'mockdesc',
+  location: 'mock location',
+  images: ['test1', 'test2', 'test3'],
+  isDogSitter: false,
+  availabilityWeek: {
+    monday: false,
+    tuesday: true,
+    wednesday: false,
+    thursday: false,
+    friday: true,
+    saturday: true,
+    sunday: true,
+  },
+  availabilityDays: {
+    additionalDays: new Date(),
+    offDays: new Date(),
+  },
+  rating: 2,
+  hourlyRate: 25,
+  tagLine: 'mock tag',
+};
+const mockOtherUserProfile3: Profile = {
+  userId: 'mockUserId',
+  firstName: 'mockFirstName',
+  lastName: 'mockLaastName',
+  description: 'mockdesc',
+  location: 'mock location',
+  images: ['test1', 'test2', 'test3'],
+  isDogSitter: false,
+  availabilityWeek: {
+    monday: false,
+    tuesday: true,
+    wednesday: false,
+    thursday: false,
+    friday: true,
+    saturday: true,
+    sunday: true,
+  },
+  availabilityDays: {
+    additionalDays: new Date(),
+    offDays: new Date(),
+  },
+  rating: 2,
+  hourlyRate: 25,
+  tagLine: 'mock tag',
+};
+
+const mockOthermockUserProfiles: Profile[] = [mockOtherUserProfile1, mockOtherUserProfile2, mockOtherUserProfile3];
+
+export { mockUserProfile, mockOthermockUserProfiles };

--- a/client/src/mocks/mockUseAuthProvider.tsx
+++ b/client/src/mocks/mockUseAuthProvider.tsx
@@ -1,12 +1,14 @@
 import { FunctionComponent } from 'react';
 import { AuthContext } from '../context/useAuthContext';
 import { mockLoggedInUser } from './mockUser';
+import { mockUserProfile } from './mockProfile';
 
 const MockUseAuthProvider: FunctionComponent = ({ children }) => {
   return (
     <AuthContext.Provider
       value={{
         loggedInUser: mockLoggedInUser,
+        userProfile: mockUserProfile,
         updateLoginContext: jest.fn(),
         logout: jest.fn(),
       }}

--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -1,6 +1,7 @@
 const User = require("../models/User");
 const asyncHandler = require("express-async-handler");
 const generateToken = require("../utils/generateToken");
+const Profile = require("../models/Profile");
 
 // @route POST /auth/register
 // @desc Register user
@@ -68,7 +69,7 @@ exports.loginUser = asyncHandler(async (req, res, next) => {
       httpOnly: true,
       maxAge: secondsInWeek * 1000,
     });
-
+    const profile = await Profile.findOne({ userId: user._id });
     res.status(200).json({
       success: {
         user: {
@@ -76,6 +77,7 @@ exports.loginUser = asyncHandler(async (req, res, next) => {
           username: user.username,
           email: user.email,
         },
+        profile: profile,
       },
     });
   } else {
@@ -94,6 +96,7 @@ exports.loadUser = asyncHandler(async (req, res, next) => {
     res.status(401);
     throw new Error("Not authorized");
   }
+  const profile = await Profile.findOne({ userId: user._id });
 
   res.status(200).json({
     success: {
@@ -102,6 +105,7 @@ exports.loadUser = asyncHandler(async (req, res, next) => {
         username: user.username,
         email: user.email,
       },
+      profile: profile,
     },
   });
 });


### PR DESCRIPTION
### What this PR does (required):
- returning profile on log in and saving it in the authContext so that it can be used through without additional api calls

### Screenshots / Videos (required):
- ![Screenshot 2021-06-23 144219](https://user-images.githubusercontent.com/12162346/123151212-3c97cf00-d431-11eb-9107-2a03745f637b.png)

### Any information needed to test this feature (required):
- Post what steps to take to be able to test this feature (eg. "sign up as a new user and upload a profile picture from the navbar")

### Any issues with the current functionality (optional):
- not sure if its the ideal way to do it
