### PR TITLE
Front end notifications

### DIFF
--- a/client/src/components/NavBar/NavBar.tsx
+++ b/client/src/components/NavBar/NavBar.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import Grid from '@material-ui/core/Grid';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import useStyles from './useStyles';
@@ -21,22 +22,42 @@ import Box from '@material-ui/core/Box';
 import MenuIcon from '@material-ui/icons/Menu';
 import LoginHeader from '../LoginHeader/LoginHeader';
 import SignupHeader from '../SignUpHeader/SignUpHeader';
+import Popover from '@material-ui/core/Popover';
+import getUnreadNotifications from '../../helpers/APICalls/getUnreadNotifications';
+import Notification from '../Notification/Notification';
+import List from '@material-ui/core/List';
 
 const NavBar = (): JSX.Element => {
   const classes = useStyles();
   const { loggedInUser, logout, userProfile } = useAuth();
   const [anchorEl, setAnchorEl] = React.useState<Element | null>(null);
+  const [notificationsAnchorEl, setNotificationsAnchorEl] = React.useState<Element | null>(null);
+  const [unreadNotifications, setUnreadNotifications] = React.useState<any[]>([]);
 
   const handleMenuClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(e.currentTarget);
   };
+
+  const handleNotificationsClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    setNotificationsAnchorEl(e.currentTarget);
+  };
+
   const handleMenuClose = () => {
     setAnchorEl(null);
+    setNotificationsAnchorEl(null);
   };
   const handleLogOut = () => {
     handleMenuClose();
     logout();
   };
+
+  useEffect(() => {
+    const fetchUnreadNotifications = async () => {
+      const data = await getUnreadNotifications()();
+      setUnreadNotifications(data.notifications);
+    };
+    fetchUnreadNotifications();
+  }, []);
 
   return (
     <Grid container component="main" className={`${classes.root}`}>
@@ -80,10 +101,49 @@ const NavBar = (): JSX.Element => {
                 <Link component={RouterLink} variant="button" to="/sitters" className={classes.link}>
                   Bookings
                 </Link>
-                <Link component={RouterLink} variant="button" to="#" className={classes.link}>
-                  Notifications
-                </Link>
-                <Badge color="primary" variant="dot" className={classes.link}>
+                <Badge
+                  color="secondary"
+                  badgeContent={unreadNotifications.length}
+                  max={99}
+                  anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+                >
+                  <Link
+                    aria-controls="notifications-menu"
+                    aria-haspopup="true"
+                    component={RouterLink}
+                    variant="button"
+                    to="#"
+                    className={classes.link}
+                    onClick={handleNotificationsClick}
+                  >
+                    Notifications
+                  </Link>
+                </Badge>
+                <Popover
+                  id={'notifications-list'}
+                  open={Boolean(notificationsAnchorEl)}
+                  anchorEl={notificationsAnchorEl}
+                  onClose={handleMenuClose}
+                  anchorOrigin={{
+                    vertical: 'bottom',
+                    horizontal: 'center',
+                  }}
+                  transformOrigin={{
+                    vertical: 'top',
+                    horizontal: 'center',
+                  }}
+                >
+                  <List>
+                    {unreadNotifications.length > 0 ? (
+                      unreadNotifications.map((notification) => (
+                        <Notification key={notification._id} title={notification.title} content={notification.content} />
+                      ))
+                    ) : (
+                      <MenuItem>You have no unread notifications</MenuItem>
+                    )}
+                  </List>
+                </Popover>
+                <Badge color="primary" variant="dot">
                   <Link
                     component={RouterLink}
                     variant="button"
@@ -122,4 +182,3 @@ const NavBar = (): JSX.Element => {
   );
 };
 export default NavBar;
-

--- a/client/src/components/Notification/Notification.tsx
+++ b/client/src/components/Notification/Notification.tsx
@@ -1,0 +1,18 @@
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
+import useStyles from './useStyles';
+
+interface Notification {
+  title: string;
+  content: string;
+}
+
+export default function Notification({ title, content }: Notification): JSX.Element {
+  const classes = useStyles();
+
+  return (
+    <ListItem>
+      <ListItemText primary={title} secondary={content} />
+    </ListItem>
+  );
+}

--- a/client/src/components/Notification/useStyles.ts
+++ b/client/src/components/Notification/useStyles.ts
@@ -1,0 +1,9 @@
+import { makeStyles, Theme } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    margin: '0 0',
+  },
+}));
+
+export default useStyles;

--- a/client/src/components/ProfilePhoto/ProfilePhoto.tsx
+++ b/client/src/components/ProfilePhoto/ProfilePhoto.tsx
@@ -9,6 +9,7 @@ import changeMainPhoto from '../../helpers/APICalls/changeMainPhoto';
 import getProfile from '../../helpers/APICalls/getProfile';
 import deletePhoto from '../../helpers/APICalls/deletePhoto';
 import { AuthContext } from '../../context/useAuthContext';
+import { useSnackBar } from '../../context/useSnackbarContext';
 
 function InputButton({ ...props }): JSX.Element {
   const classes = useStyles();
@@ -17,7 +18,7 @@ function InputButton({ ...props }): JSX.Element {
     target: HTMLInputElement & EventTarget;
   }
 
-  console.log(props);
+  const { updateSnackBarMessage } = useSnackBar();
 
   const validateAndUploadFile = (e: HTMLInputEvent | React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files) {
@@ -32,6 +33,11 @@ function InputButton({ ...props }): JSX.Element {
           const data = await uploadPhoto('profilePhoto', file);
           const images = data.profile.images;
           props.setPhotos(images);
+          if (data.error) {
+            updateSnackBarMessage(data.error.message);
+          } else {
+            updateSnackBarMessage('You have successfully uploaded a new photo');
+          }
         };
         addPhoto();
       }
@@ -48,6 +54,8 @@ function InputButton({ ...props }): JSX.Element {
 
 export default function ProfilePhoto(): JSX.Element {
   const classes = useStyles();
+
+  const { updateSnackBarMessage } = useSnackBar();
 
   const { loggedInUser } = useContext(AuthContext);
   const loggedInUserId: string = loggedInUser !== null && loggedInUser !== undefined ? loggedInUser.id : '';
@@ -67,6 +75,11 @@ export default function ProfilePhoto(): JSX.Element {
       const data = await changeMainPhoto(idx);
       const images = data.profile.images;
       setPhotos(images);
+      if (data.error) {
+        updateSnackBarMessage(data.error.message);
+      } else {
+        updateSnackBarMessage('You have successfully updated your main photo');
+      }
     };
     setNewMainPhoto();
   };
@@ -76,6 +89,11 @@ export default function ProfilePhoto(): JSX.Element {
       const data = await deletePhoto(photo, index);
       const images = data.profile.images;
       setPhotos(images);
+      if (data.error) {
+        updateSnackBarMessage(data.error.message);
+      } else {
+        updateSnackBarMessage('You have successfully deleted a photo');
+      }
     };
     deleteCurrentPhoto();
   };

--- a/client/src/helpers/APICalls/getUnreadNotifications.ts
+++ b/client/src/helpers/APICalls/getUnreadNotifications.ts
@@ -1,0 +1,16 @@
+import { FetchOptions } from '../../interface/FetchOptions';
+
+const getUnreadNotifications = () => async () : Promise<any> => {
+  const fetchOptions: FetchOptions = {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+  };
+ return await fetch(`http://localhost:3001/notifications/unread`, fetchOptions)
+    .then((res) => res.json())
+    .catch(() => ({
+      error: { message: 'Unable to connect to server. Please try again' },
+    }));
+};
+
+export default getUnreadNotifications;


### PR DESCRIPTION
### What this PR does (required):
- user can view the number of unread notifications in the navbar
- clicking on the notifications link will open a popup with notification details
- 
### Screenshots / Videos (required):

![image](https://user-images.githubusercontent.com/28031233/123462848-d2119b00-d5b8-11eb-9119-9442b53547c8.png)

### Any information needed to test this feature (required):
- `npm run start` 
- the user needs to sign up or log in
- notifications cannot be viewed if the user does not have any notifications

### Any issues with the current functionality (optional):
- there should be a link to view all notifications when the "notifications" button is pressed
- the length of the notification content should be trimmed for longer messages
