### PR TITLE
Front end notifications edits & fix new user bug

### DIFF
--- a/client/src/components/EditProfile/EditProfile.tsx
+++ b/client/src/components/EditProfile/EditProfile.tsx
@@ -26,7 +26,12 @@ import getProfile from '../../helpers/APICalls/getProfile';
 import { useSnackBar } from '../../context/useSnackbarContext';
 import { CurrentProfile } from '../../interface/AuthApiData'
 
-export default function EditProfile(): JSX.Element {
+
+interface Props {
+  newUser: boolean
+}
+
+export default function EditProfile({newUser}: Props): JSX.Element {
   const classes = useStyles();
 
   const [isDogSitter, setIsDogSitter] = useState(false);
@@ -148,16 +153,27 @@ export default function EditProfile(): JSX.Element {
     });
   };
 
+  useEffect(() => {
+    const fetchProfile = async () => {
+      const data = await getProfile(loggedInUserId)();
+      if (data.profile) {
+      setCurrentProfile(data);
+      setIsDogSitter(data.profile.isDogSitter)
+      }
+    };
+    fetchProfile();
+  }, [loggedInUserId]);
+
   const formik = useFormik({
     enableReinitialize: true,
     initialValues: {
       isDogSitter: CurrentProfile.profile.isDogSitter,
       firstName: CurrentProfile.profile.firstName,
-      lastName: CurrentProfile.profile.lastName,
+      lastName: CurrentProfile.profile.lastName === '(n/a)' ? '' : CurrentProfile.profile.lastName,
       primaryPhone: '',
       secondaryPhone: '',
-      location: CurrentProfile.profile.location,
-      selfDescription: CurrentProfile.profile.description,
+      location: CurrentProfile.profile.location === '(this user has not set a location yet)' ? '' : CurrentProfile.profile.location,
+      selfDescription: CurrentProfile.profile.description === '(this user has not written a description yet)' ? '' : CurrentProfile.profile.description,
       hourlyRate: CurrentProfile.profile.hourlyRate,
       tagLine: CurrentProfile.profile.tagLine,
       availability: {
@@ -265,18 +281,10 @@ export default function EditProfile(): JSX.Element {
     onSubmit: (values) => handleSubmit(values),
   });
 
-  useEffect(() => {
-    const fetchProfile = async () => {
-      const data = await getProfile(loggedInUserId)();
-      setCurrentProfile(data);
-      setIsDogSitter(data.profile.isDogSitter)
-    };
-    fetchProfile();
-  }, [loggedInUserId]);
-
   return (
     <Grid className={classes.root}>
       <CssBaseline />
+      {newUser === true && <Typography className={classes.newUserHeading}>Welcome to Loving Sitter! To begin, let&apos;s start with setting up your profile. </Typography>}
       <form onSubmit={formik.handleSubmit}>
         <Grid className={classes.formItem}>
           <Typography className={classes.formLabel}>I WANT TO DOG SIT</Typography>

--- a/client/src/components/EditProfile/EditProfile.tsx
+++ b/client/src/components/EditProfile/EditProfile.tsx
@@ -25,7 +25,7 @@ import editProfile from '../../helpers/APICalls/editProfile';
 import getProfile from '../../helpers/APICalls/getProfile';
 import { useSnackBar } from '../../context/useSnackbarContext';
 import { CurrentProfile } from '../../interface/AuthApiData'
-
+import { useHistory } from 'react-router-dom';
 
 interface Props {
   newUser: boolean
@@ -97,6 +97,7 @@ export default function EditProfile({newUser}: Props): JSX.Element {
   const DAYS_OF_THE_WEEK = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
   const { updateSnackBarMessage } = useSnackBar();
+  const history = useHistory();
 
   const handleSubmit = ({
     isDogSitter,
@@ -149,6 +150,7 @@ export default function EditProfile({newUser}: Props): JSX.Element {
         updateSnackBarMessage(data.error.message);
       } else {
         updateSnackBarMessage('Your profile has been upated');
+        if (newUser === true) history.push({pathname: '/dashboard'})
       }
     });
   };
@@ -284,6 +286,7 @@ export default function EditProfile({newUser}: Props): JSX.Element {
   return (
     <Grid className={classes.root}>
       <CssBaseline />
+      {/* Replace the line below when using Reactour */}
       {newUser === true && <Typography className={classes.newUserHeading}>Welcome to Loving Sitter! To begin, let&apos;s start with setting up your profile. </Typography>}
       <form onSubmit={formik.handleSubmit}>
         <Grid className={classes.formItem}>

--- a/client/src/components/EditProfile/useStyles.ts
+++ b/client/src/components/EditProfile/useStyles.ts
@@ -6,6 +6,11 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: 'column',
     marginTop: '20px',
   },
+  newUserHeading: {
+    textAlign: 'center',
+    fontSize: '1.1rem',
+    fontWeight: 500,
+  }, 
   formItem: {
     display: 'flex',
     flexDirection: 'row',

--- a/client/src/components/NavBar/NavBar.tsx
+++ b/client/src/components/NavBar/NavBar.tsx
@@ -68,7 +68,7 @@ const NavBar = (): JSX.Element => {
       setUnreadNotifications(data.notifications.sort((a: Notification, b: Notification) => new Date(b.date).valueOf() - new Date(a.date).valueOf() ));
     };
     fetchUnreadNotifications();
-  }, []);
+  }, [loggedInUser]);
 
   return (
     <Grid container component="main" className={`${classes.root}`}>

--- a/client/src/components/NavBar/NavBar.tsx
+++ b/client/src/components/NavBar/NavBar.tsx
@@ -26,6 +26,17 @@ import Popover from '@material-ui/core/Popover';
 import getUnreadNotifications from '../../helpers/APICalls/getUnreadNotifications';
 import Notification from '../Notification/Notification';
 import List from '@material-ui/core/List';
+import Divider from '@material-ui/core/Divider';
+
+interface Notification {
+  title: string;
+  content: string;
+  date: Date;
+  sender: string;
+  recipient: string;
+  type: string;
+  read: boolean;
+}
 
 const NavBar = (): JSX.Element => {
   const classes = useStyles();
@@ -54,7 +65,7 @@ const NavBar = (): JSX.Element => {
   useEffect(() => {
     const fetchUnreadNotifications = async () => {
       const data = await getUnreadNotifications()();
-      setUnreadNotifications(data.notifications);
+      setUnreadNotifications(data.notifications.sort((a: Notification, b: Notification) => new Date(b.date).valueOf() - new Date(a.date).valueOf() ));
     };
     fetchUnreadNotifications();
   }, []);
@@ -101,48 +112,66 @@ const NavBar = (): JSX.Element => {
                 <Link component={RouterLink} variant="button" to="/sitters" className={classes.link}>
                   Bookings
                 </Link>
-                <Badge
-                  color="secondary"
-                  badgeContent={unreadNotifications.length}
-                  max={99}
-                  anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
-                >
-                  <Link
-                    aria-controls="notifications-menu"
-                    aria-haspopup="true"
-                    component={RouterLink}
-                    variant="button"
-                    to="#"
-                    className={classes.link}
-                    onClick={handleNotificationsClick}
-                  >
-                    Notifications
-                  </Link>
-                </Badge>
-                <Popover
-                  id={'notifications-list'}
-                  open={Boolean(notificationsAnchorEl)}
-                  anchorEl={notificationsAnchorEl}
-                  onClose={handleMenuClose}
-                  anchorOrigin={{
-                    vertical: 'bottom',
-                    horizontal: 'center',
-                  }}
-                  transformOrigin={{
-                    vertical: 'top',
-                    horizontal: 'center',
-                  }}
-                >
-                  <List>
-                    {unreadNotifications.length > 0 ? (
-                      unreadNotifications.map((notification) => (
-                        <Notification key={notification._id} title={notification.title} content={notification.content} />
-                      ))
-                    ) : (
-                      <MenuItem>You have no unread notifications</MenuItem>
-                    )}
-                  </List>
-                </Popover>
+                {unreadNotifications && (
+                  <>
+                    <Badge
+                      color="secondary"
+                      badgeContent={unreadNotifications.length}
+                      max={99}
+                      anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+                    >
+                      <Link
+                        aria-controls="notifications-menu"
+                        aria-haspopup="true"
+                        component={RouterLink}
+                        variant="button"
+                        to="#"
+                        className={classes.link}
+                        onClick={handleNotificationsClick}
+                      >
+                        Notifications
+                      </Link>
+                    </Badge>
+                    <Popover
+                      id={'notifications-list'}
+                      open={Boolean(notificationsAnchorEl)}
+                      anchorEl={notificationsAnchorEl}
+                      onClose={handleMenuClose}
+                      anchorOrigin={{
+                        vertical: 'bottom',
+                        horizontal: 'center',
+                      }}
+                      transformOrigin={{
+                        vertical: 'top',
+                        horizontal: 'center',
+                      }}
+                    >
+                      <List>
+                        {unreadNotifications.length > 0 ? (
+                          unreadNotifications.map((notification, idx) => (
+                            <>
+                              <Notification
+                                key={notification._id}
+                                title={notification.title}
+                                content={notification.content}
+                                date={notification.date}
+                              />
+                              {idx === unreadNotifications.length - 1 ? (
+                                <Link>
+                                  <Typography className={classes.notificationsLink}>View all notifications</Typography>
+                                </Link>
+                              ) : (
+                                <Divider />
+                              )}
+                            </>
+                          ))
+                        ) : (
+                          <MenuItem>You have no unread notifications</MenuItem>
+                        )}
+                      </List>
+                    </Popover>
+                  </>
+                )}
                 <Badge color="primary" variant="dot">
                   <Link
                     component={RouterLink}

--- a/client/src/components/NavBar/NavBar.tsx
+++ b/client/src/components/NavBar/NavBar.tsx
@@ -65,7 +65,13 @@ const NavBar = (): JSX.Element => {
   useEffect(() => {
     const fetchUnreadNotifications = async () => {
       const data = await getUnreadNotifications()();
-      setUnreadNotifications(data.notifications.sort((a: Notification, b: Notification) => new Date(b.date).valueOf() - new Date(a.date).valueOf() ));
+      if (data.notifications) {
+        setUnreadNotifications(
+          data.notifications.sort(
+            (a: Notification, b: Notification) => new Date(b.date).valueOf() - new Date(a.date).valueOf(),
+          ),
+        );
+      }
     };
     fetchUnreadNotifications();
   }, [loggedInUser]);

--- a/client/src/components/NavBar/useStyles.ts
+++ b/client/src/components/NavBar/useStyles.ts
@@ -7,7 +7,6 @@ const useStyles = makeStyles((theme: Theme) => ({
 
   appBar: {
     backgroundColor: '#FFFFFF',
-  
   },
   toolbar: {
     margin: `auto 0`,
@@ -21,11 +20,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: 'flex',
     alignItems: 'center',
   },
-   toolbarLink: {
-     color: '#000000',
-     fontWeight: 800,
-     fontSize: 12,
-     fontFamily: '"Open Sans", "sans-serif", "Roboto"',
+  toolbarLink: {
+    color: '#000000',
+    fontWeight: 800,
+    fontSize: 12,
+    fontFamily: '"Open Sans", "sans-serif", "Roboto"',
     marginRight: 24,
   },
   secondaryLink: {
@@ -35,10 +34,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginLeft: '8px',
   },
   toolbarIcon: {
-
     fontSize: '2.8rem',
     color: theme.palette.primary.main,
-    margin: '0.5rem'
+    margin: '0.5rem',
   },
   toolbarLeftContainer: {
     width: 'auto',
@@ -93,7 +91,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginRight: 20,
     height: 40,
     width: 'auto',
-  }
+  },
+  notificationsLink: {
+    textAlign: 'center',
+  },
 }));
 
 export default useStyles;

--- a/client/src/components/Notification/Notification.tsx
+++ b/client/src/components/Notification/Notification.tsx
@@ -19,7 +19,7 @@ export default function Notification({ title, content, date }: Notification): JS
   return (
     <ListItem>
       {console.log(date)}
-      <ListItemText primary={title} secondary={content.length > 40 ? `${notificationDate(date)} - ${content.slice(0, 37)}...` : content} />
+      <ListItemText primary={title} secondary={content.length > 40 ? `${notificationDate(date)} - ${content.slice(0, 30)}...` : content} />
     </ListItem>
   );
 }

--- a/client/src/components/Notification/Notification.tsx
+++ b/client/src/components/Notification/Notification.tsx
@@ -1,18 +1,25 @@
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import useStyles from './useStyles';
+import moment from 'moment';
 
 interface Notification {
   title: string;
   content: string;
+  date: Date;
 }
 
-export default function Notification({ title, content }: Notification): JSX.Element {
+export default function Notification({ title, content, date }: Notification): JSX.Element {
   const classes = useStyles();
+
+  const notificationDate = (date: Date) => {
+    return moment(date).fromNow()
+  };
 
   return (
     <ListItem>
-      <ListItemText primary={title} secondary={content} />
+      {console.log(date)}
+      <ListItemText primary={title} secondary={content.length > 40 ? `${notificationDate(date)} - ${content.slice(0, 37)}...` : content} />
     </ListItem>
   );
 }

--- a/client/src/components/ProfilePhoto/ProfilePhoto.tsx
+++ b/client/src/components/ProfilePhoto/ProfilePhoto.tsx
@@ -10,6 +10,11 @@ import getProfile from '../../helpers/APICalls/getProfile';
 import deletePhoto from '../../helpers/APICalls/deletePhoto';
 import { AuthContext } from '../../context/useAuthContext';
 import { useSnackBar } from '../../context/useSnackbarContext';
+import { useHistory } from 'react-router-dom';
+
+interface Props {
+  newUser: boolean
+}
 
 function InputButton({ ...props }): JSX.Element {
   const classes = useStyles();
@@ -52,10 +57,11 @@ function InputButton({ ...props }): JSX.Element {
   );
 }
 
-export default function ProfilePhoto(): JSX.Element {
+export default function ProfilePhoto({newUser}: Props): JSX.Element {
   const classes = useStyles();
 
   const { updateSnackBarMessage } = useSnackBar();
+  const history = useHistory();
 
   const { loggedInUser } = useContext(AuthContext);
   const loggedInUserId: string = loggedInUser !== null && loggedInUser !== undefined ? loggedInUser.id : '';
@@ -79,6 +85,7 @@ export default function ProfilePhoto(): JSX.Element {
         updateSnackBarMessage(data.error.message);
       } else {
         updateSnackBarMessage('You have successfully updated your main photo');
+        if (newUser === true) history.push('/dashboard')
       }
     };
     setNewMainPhoto();
@@ -101,6 +108,8 @@ export default function ProfilePhoto(): JSX.Element {
   return (
     <Grid className={classes.root}>
       <CssBaseline />
+      {/* Replace the line below when using Reactour */}
+      {newUser === true && <Typography className={classes.newUserHeading}>Next, let&apos;s upload some photos to your profile! </Typography>}
       <Carousel autoPlay={false}>
         {photos.map((item, idx) => (
           <Grid key={idx} className={classes.photoContainer}>

--- a/client/src/components/ProfilePhoto/useStyles.ts
+++ b/client/src/components/ProfilePhoto/useStyles.ts
@@ -9,6 +9,11 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: 'center',
     marginTop: '30px',
   },
+  newUserHeading: {
+    textAlign: 'center',
+    fontSize: '1.1rem',
+    fontWeight: 500,
+  }, 
   settingsSubheading: {
     fontSize: '1.2rem',
     color: '#8D8D8D',

--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -45,7 +45,7 @@ export default function Profile(props: any): JSX.Element {
       </Grid>
       <Container maxWidth="md" className={classes.menuContainer}>
         {currentSection === 'editprofile' && <EditProfile newUser={isNewUser()}/>}
-        {currentSection === 'profilephoto' && <ProfilePhoto />}
+        {currentSection === 'profilephoto' && <ProfilePhoto newUser={isNewUser()}/>}
         {currentSection === 'payment' && <Payment />}
         {currentSection === 'security' && <Security />}
         {currentSection === 'settings' && <Settings />}

--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -20,6 +20,14 @@ export default function Profile(props: any): JSX.Element {
     props.history.push(`/profile/${section}`);
   };
 
+  const isNewUser = () => {
+    if (props.location.state === undefined) {
+      return false
+    } else {
+      return props.location.state.newUser
+    }
+  }
+
   return (
     <Grid container className={`${classes.root}`}>
       <CssBaseline />
@@ -36,7 +44,7 @@ export default function Profile(props: any): JSX.Element {
         ))}
       </Grid>
       <Container maxWidth="md" className={classes.menuContainer}>
-        {currentSection === 'editprofile' && <EditProfile />}
+        {currentSection === 'editprofile' && <EditProfile newUser={isNewUser()}/>}
         {currentSection === 'profilephoto' && <ProfilePhoto />}
         {currentSection === 'payment' && <Payment />}
         {currentSection === 'security' && <Security />}

--- a/client/src/pages/SignUp/SignUp.tsx
+++ b/client/src/pages/SignUp/SignUp.tsx
@@ -29,7 +29,7 @@ export default function Register(): JSX.Element {
         updateSnackBarMessage(data.error.message);
       } else if (data.success) {
         updateLoginContext(data.success);
-        history.push('/profile');
+        history.push({pathname: '/profile/editprofile', state: {newUser: true}});
       } else {
         // should not get here from backend but this catch is for an unknown issue
         console.error({ data });

--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -29,6 +29,16 @@ exports.registerUser = asyncHandler(async (req, res, next) => {
     password,
   });
 
+  await Profile.create({
+    userId: user._id,
+    firstName: username,
+    lastName: '(n/a)',
+    description: '(this user has not written a description yet)',
+    location: '(this user has not set a location yet)',
+    isDogSitter: false,
+    hourlyRate: 15,
+  })
+
   if (user) {
     const token = generateToken(user._id);
     const secondsInWeek = 604800;

--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -28,6 +28,7 @@ const profileSchema = new mongoose.Schema({
       type: String,
     },
   ],
+  default: [],
 
   //  sitter
   isDogSitter: {


### PR DESCRIPTION
### What this PR does (required):
- notifications on the front end now are listed in chronological order starting from the most recent notification
- A bug was fixed where the app would crash when a new user signed up. This was because a new user would be redirected to the "Edit Profile" section where the profile details were populated in the form. Because a new user did not have a profile the site would crash when redirected to the "Edit Profile" section. The user is now redirected to the "Edit Profile" form with a message stating that they should complete their profile before using the site

### Screenshots / Videos (required):
![image](https://user-images.githubusercontent.com/28031233/123578591-2d53b100-d7a4-11eb-9133-057b6c98c810.png)

![image](https://user-images.githubusercontent.com/28031233/123578635-3d6b9080-d7a4-11eb-9f79-d902edff1fb1.png)


### Any information needed to test this feature (required):
- To test the "Edit Profile" feature for new users, a user must sign up for the site
- To test the notifications, a user with notifications must click on the "Notifications" button on the navbar

### Any issues with the current functionality (optional):
- we are still working on limiting the number of notifications that can be seen in the popover for the "Notificatons" button on the navbar. 
- we are also working on adding an icon next to each notification in the popover that will mark the notification as read