### PR TITLE
fix changing main photo and sending images

### DIFF
--- a/client/src/pages/Messages/useStyles.ts
+++ b/client/src/pages/Messages/useStyles.ts
@@ -7,7 +7,7 @@ const useStyles = makeStyles((theme) => ({
     marginTop: '60px',
     display: 'flex',
     flexDirection: 'row',
-    maxHeight: '100vh',
+    maxHeight: '100vh - 85px',
   },
   conversationsHeading: {
     fontSize: '1.2rem',
@@ -36,7 +36,7 @@ const useStyles = makeStyles((theme) => ({
   },
   '@keyframes showOptions': {
     '0%': {
-      transform: 'translateX(-10px)',
+      transform: 'translateX(-80px)',
     },
     '100%': {
       transform: 'translateX(0px)',
@@ -55,7 +55,7 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
-    transform: 'translateX(-10px)',
+    transform: 'translateX(-80px)',
     zIndex: -3,
     width: '500px',
   },

--- a/server/controllers/profile.js
+++ b/server/controllers/profile.js
@@ -144,15 +144,14 @@ exports.findSittersByLocation = asyncHandler(async (req, res) => {
 //@route Get /profile/day/:search
 //return list of profiles who match users selected day(s)
 exports.findSittersByDay = asyncHandler(async (req, res) => {
-
   let findQuery = { $and: [] };
   let search = [req.params.search];
 
   search.forEach((a) => {
-    let aName = `availabilityWeek.${a}`
-    findQuery['$and'].push({
-      [aName]: true
-    })
+    let aName = `availabilityWeek.${a}`;
+    findQuery["$and"].push({
+      [aName]: true,
+    });
   });
 
   try {
@@ -166,7 +165,7 @@ exports.findSittersByDay = asyncHandler(async (req, res) => {
   } catch (error) {
     return res.status(500).json({ message: error });
   }
-})
+});
 
 // @route POST /profile/uploadphoto/
 // Upload photo
@@ -199,7 +198,10 @@ exports.changeMainPhoto = asyncHandler(async (req, res) => {
       const temp = profile.images[0];
       profile.images[0] = profile.images[index];
       profile.images[index] = temp;
-      await profile.save();
+      await Profile.findOneAndUpdate(
+        { userId },
+        { $set: { images: profile.images } }
+      );
       res.status(200).json({ profile });
     } else {
       res.status(404).json({ message: "Profile Not Found" });


### PR DESCRIPTION
### What this PR does (required):
- in prior pull requests the user was able to change their main photo. However, it was not persistent. The controller was changed so that the changes are now saved on the DB
- a previous PR added sending images functionality to the messages page but the messages page was not committed and as a result the changes were lost. This PR adds those changes back to the messages page
-
### Screenshots / Videos (required):
- see videos and screenshots from the prior related pull requests
- 
### Any information needed to test this feature (required):
- user needs to log on
- a user needs to have at least two profile photos in order to set a new main one

### Any issues with the current functionality (optional):
- image sizes in messages are still not optimal. Some work on the CSS needs to be done
