### PR TITLE
add functional notifications page

### DIFF
--- a/client/src/components/NavBar/NavBar.tsx
+++ b/client/src/components/NavBar/NavBar.tsx
@@ -195,6 +195,8 @@ const NavBar = (): JSX.Element => {
                                   content={notification.content}
                                   date={notification.createdAt}
                                   type={notification.type}
+                                  read={true}
+                                  id={notification._id}
                                 />
                                 {idx === unreadNotifications.length - 1 ? (
                                   <>

--- a/client/src/components/Notification/Notification.tsx
+++ b/client/src/components/Notification/Notification.tsx
@@ -1,4 +1,4 @@
-import { ListItem, ListItemText, InputAdornment } from '@material-ui/core/';
+import { ListItem, ListItemText, Grid } from '@material-ui/core/';
 import useStyles from './useStyles';
 import moment from 'moment';
 import MessageIcon from '@material-ui/icons/Message';
@@ -12,9 +12,11 @@ interface Notification {
   content: string;
   date: Date;
   type: string;
+  read: boolean;
+  id: string;
 }
 
-export default function Notification({ title, content, date, type }: Notification): JSX.Element {
+export default function Notification({ id, title, content, date, type, read }: Notification): JSX.Element {
   const classes = useStyles();
 
   const notificationDate = (date: Date) => {
@@ -37,13 +39,9 @@ export default function Notification({ title, content, date, type }: Notificatio
   };
 
   return (
-    <ListItem>
+    <ListItem className={read === false ? classes.unread : ''}>
       {getIcon(type)}
-      <ListItemText
-        className={classes.root}
-        primary={title}
-        secondary={content.length > 40 ? `${notificationDate(date)} - ${content.slice(0, 30)}...` : content}
-      />
+      <ListItemText className={classes.root} primary={title} secondary={`${notificationDate(date)} - ${content}`} />
     </ListItem>
   );
 }

--- a/client/src/components/Notification/useStyles.ts
+++ b/client/src/components/Notification/useStyles.ts
@@ -4,6 +4,14 @@ const useStyles = makeStyles((theme: Theme) => ({
   root: {
     marginLeft: '10px',
   },
+  unread: {
+    backgroundColor: '#bbb',
+  },
+  notificationsContainer: {
+    '&:hover': {
+      pointer: 'cursor',
+    },
+  },
 }));
 
 export default useStyles;

--- a/client/src/components/ProfilePhoto/ProfilePhoto.tsx
+++ b/client/src/components/ProfilePhoto/ProfilePhoto.tsx
@@ -75,6 +75,7 @@ export default function ProfilePhoto(): JSX.Element {
   const updateMainPhoto = (idx: number) => {
     const setNewMainPhoto = async () => {
       const data = await changeMainPhoto(idx);
+      console.log(data.profile.images);
       const images = data.profile.images;
       setPhotos(images);
       if (data.error) {
@@ -90,6 +91,7 @@ export default function ProfilePhoto(): JSX.Element {
     const deleteCurrentPhoto = async () => {
       const data = await deletePhoto(photo, index);
       const images = data.profile.images;
+      console.log(images);
       setPhotos(images);
       if (data.error) {
         updateSnackBarMessage(data.error.message);

--- a/client/src/helpers/APICalls/getAllNotifications.ts
+++ b/client/src/helpers/APICalls/getAllNotifications.ts
@@ -1,0 +1,16 @@
+import { FetchOptions } from '../../interface/FetchOptions';
+
+const getUnreadNotifications = () => async (): Promise<any> => {
+  const fetchOptions: FetchOptions = {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+  };
+  return await fetch(`http://localhost:3001/notifications/all`, fetchOptions)
+    .then((res) => res.json())
+    .catch(() => ({
+      error: { message: 'Unable to connect to server. Please try again' },
+    }));
+};
+
+export default getUnreadNotifications;

--- a/client/src/helpers/APICalls/markNotificationAsRead.ts
+++ b/client/src/helpers/APICalls/markNotificationAsRead.ts
@@ -1,8 +1,16 @@
 import { FetchOptions } from '../../interface/FetchOptions';
-import { INotification } from '../../interface/Notification';
 
-export const patchNotificationAsRead = async (): Promise<any> => {
-  console.log('marking notification as read');
+export const patchNotificationAsRead = async (id: string): Promise<any> => {
+  const fetchOptions: FetchOptions = {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+  };
+  return await fetch(`http://localhost:3001/notifications/read/${id}`, fetchOptions)
+    .then((res) => res.json())
+    .catch(() => ({
+      error: { message: 'Unable to connect to server. Please try again' },
+    }));
 };
 
 export const patchAllNotificationsAsRead = async (): Promise<any> => {

--- a/client/src/pages/Notifications/Notifications.tsx
+++ b/client/src/pages/Notifications/Notifications.tsx
@@ -9,6 +9,7 @@ import getAllNotifications from '../../helpers/APICalls/getAllNotifications';
 import Notification from '../../components/Notification/Notification';
 import { INotification } from '../../interface/Notification';
 import { patchNotificationAsRead } from '../../helpers/APICalls/markNotificationAsRead';
+import { useSocket } from '../../context/useSocketContext';
 
 interface TabPanelProps {
   children?: React.ReactNode;
@@ -43,6 +44,7 @@ function a11yProps(index: number) {
 export default function FullWidthTabs(): JSX.Element {
   const classes = NotificationsTabStyle();
   const theme = useTheme();
+
   const [value, setValue] = React.useState(0);
 
   const handleChange = (event: React.ChangeEvent<any>, newValue: number) => {
@@ -79,6 +81,7 @@ export default function FullWidthTabs(): JSX.Element {
 const Notifications = ({ apiCall }: any): JSX.Element => {
   const classes = useStyles();
   const { loggedInUser } = useAuth();
+  const { socket } = useSocket();
 
   const [notifications, setNotifications] = useState<INotification[]>([]);
 
@@ -87,6 +90,13 @@ const Notifications = ({ apiCall }: any): JSX.Element => {
     if (selectedNotification.read === false && apiCall === 'getUnreadNotifications') {
       patchNotificationAsRead(id);
       setNotifications(notifications.filter((notification) => notification._id !== id));
+      if (socket !== undefined) {
+        socket.emit('clearNotification', {
+          type: 'readNotification',
+          sender: loggedInUser?.id,
+          recipient: loggedInUser?.id,
+        });
+      }
     }
   };
 

--- a/client/src/pages/Notifications/Notifications.tsx
+++ b/client/src/pages/Notifications/Notifications.tsx
@@ -1,11 +1,129 @@
-import { useState } from 'react';
-import Typography from '@material-ui/core/Typography';
+import React, { useState, useEffect } from 'react';
+import { useAuth } from '../../context/useAuthContext';
+import { Typography, AppBar, Tabs, Tab, Box, Grid, Container, Divider } from '@material-ui/core';
 import useStyles from './useStyles';
+import { useTheme } from '@material-ui/core/styles';
+import NotificationsTabStyle from './NotificationsTabStyles';
+import getUnreadNotifications from '../../helpers/APICalls/getUnreadNotifications';
+import getAllNotifications from '../../helpers/APICalls/getAllNotifications';
+import Notification from '../../components/Notification/Notification';
+import { INotification } from '../../interface/Notification';
+import { patchNotificationAsRead } from '../../helpers/APICalls/markNotificationAsRead';
 
-const Message = (): JSX.Element => {
+interface TabPanelProps {
+  children?: React.ReactNode;
+  dir?: string;
+  index: number;
+  value: number;
+}
+
+function TabPanel(props: TabPanelProps) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`full-width-tabpanel-${index}`}
+      aria-labelledby={`full-width-tab-${index}`}
+      {...other}
+    >
+      {value === index && <Box p={3}>{children}</Box>}
+    </div>
+  );
+}
+
+function a11yProps(index: number) {
+  return {
+    id: `full-width-tab-${index}`,
+    'aria-controls': `full-width-tabpanel-${index}`,
+  };
+}
+
+export default function FullWidthTabs(): JSX.Element {
+  const classes = NotificationsTabStyle();
+  const theme = useTheme();
+  const [value, setValue] = React.useState(0);
+
+  const handleChange = (event: React.ChangeEvent<any>, newValue: number) => {
+    setValue(newValue);
+  };
+
+  return (
+    <div className={classes.root}>
+      <AppBar position="static" color="default" className={classes.tabBar}>
+        <Tabs
+          value={value}
+          onChange={handleChange}
+          indicatorColor="primary"
+          textColor="primary"
+          variant="fullWidth"
+          aria-label="full width tabs example"
+          centered
+        >
+          <Tab label="All" {...a11yProps(1)} />
+          <Tab label="Unread" {...a11yProps(0)} />
+        </Tabs>
+      </AppBar>
+
+      <TabPanel value={value} index={0} dir={theme.direction}>
+        <Notifications apiCall="getAllNotifications"></Notifications>
+      </TabPanel>
+      <TabPanel value={value} index={1} dir={theme.direction}>
+        <Notifications apiCall="getUnreadNotifications"></Notifications>
+      </TabPanel>
+    </div>
+  );
+}
+
+const Notifications = ({ apiCall }: any): JSX.Element => {
   const classes = useStyles();
+  const { loggedInUser } = useAuth();
 
-  return <Typography>This is the notifications page</Typography>;
+  const [notifications, setNotifications] = useState<INotification[]>([]);
+
+  const markAsRead = async (id: string) => {
+    const selectedNotification = notifications.filter((notification) => notification._id === id)[0];
+    if (selectedNotification.read === false && apiCall === 'getUnreadNotifications') {
+      patchNotificationAsRead(id);
+      setNotifications(notifications.filter((notification) => notification._id !== id));
+    }
+  };
+
+  useEffect(() => {
+    const fetchRequest = apiCall === 'getUnreadNotifications' ? getUnreadNotifications : getAllNotifications;
+    const fetchNotifications = async () => {
+      const data = await fetchRequest()();
+      console.log(data);
+      if (data.notifications) {
+        setNotifications(
+          data.notifications.sort(
+            (a: INotification, b: INotification) => new Date(b.createdAt).valueOf() - new Date(a.createdAt).valueOf(),
+          ),
+        );
+      }
+    };
+    fetchNotifications();
+  }, [loggedInUser, apiCall]);
+
+  return (
+    <Container className={classes.root}>
+      {notifications.length > 0
+        ? notifications.map((notification) => (
+            <Grid key={notification._id} onClick={() => markAsRead(notification._id)}>
+              <Notification
+                key={notification._id}
+                title={notification.title}
+                content={notification.content}
+                date={notification.createdAt}
+                type={notification.type}
+                read={notification.read}
+                id={notification._id}
+              />
+              <Divider />
+            </Grid>
+          ))
+        : `You have no notifications`}
+    </Container>
+  );
 };
-
-export default Message;

--- a/client/src/pages/Notifications/NotificationsTabStyles.ts
+++ b/client/src/pages/Notifications/NotificationsTabStyles.ts
@@ -1,0 +1,14 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const NotificationsTabStyle = makeStyles((theme) => ({
+  root: {
+    paddingTop: theme.spacing(3.2),
+  },
+  tabBar: {
+    marginTop: theme.spacing(8),
+    maxWidth: 800,
+    margin: 'auto',
+  },
+}));
+
+export default NotificationsTabStyle;

--- a/client/src/pages/Notifications/useStyles.ts
+++ b/client/src/pages/Notifications/useStyles.ts
@@ -1,7 +1,12 @@
 import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme) => ({
-  root: {},
+  root: {
+    maxHeight: '60vh',
+    overflowY: 'scroll',
+    paddingTop: theme.spacing(3.2),
+    maxWidth: '800px',
+  },
 }));
 
 export default useStyles;

--- a/server/controllers/notifications.js
+++ b/server/controllers/notifications.js
@@ -78,6 +78,7 @@ exports.readNotification = asyncHandler(async (req, res) => {
       { _id: notificationId },
       { read: true }
     );
+    console.log(`notification: ${notificationId} has been updated`);
     res.status(200).json({
       notification,
     });

--- a/server/socket/index.js
+++ b/server/socket/index.js
@@ -39,6 +39,14 @@ exports.appSocket = (server) => {
       });
     });
 
+    socket.on("clearNotification", ({ type, sender, recipient }) => {
+      socket.emit("notification", {
+        type,
+        from: sender,
+        to: recipient,
+      });
+    });
+
     socket.on("message", ({ sender, recipient }) => {
       socket.broadcast.emit("message", {
         from: sender,


### PR DESCRIPTION
### What this PR does (required):
- user can go to the notifications page
- the notifications page has two tabs: one for all notifications and one for unread notifications
- if a user clicks on an unread notification in the unread notifications section then it will be removed from that section
-
### Screenshots / Videos (required):
![image](https://user-images.githubusercontent.com/28031233/125112945-e627c300-e0b5-11eb-98ae-fcb6a1e1f5e1.png)

### Any information needed to test this feature (required):
- user needs to log in 
- the user must have some notifications. Notifications are received when another user books or cancels a request from the user

### Any issues with the current functionality (optional):
- click on an unread notification in the "all" notifications section will not mark it as read
